### PR TITLE
Fix parameter type casting to int

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "emr-clusters",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "meta": {
         "label": "EMR clusters",
         "description": "Dynamically create Amazon EMR clusters or attach to existing ones.",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "emr-clusters",
-    "version": "0.0.3",
+    "version": "0.0.2",
     "meta": {
         "label": "EMR clusters",
         "description": "Dynamically create Amazon EMR clusters or attach to existing ones.",

--- a/python-clusters/emr-create-cluster/cluster.py
+++ b/python-clusters/emr-create-cluster/cluster.py
@@ -29,7 +29,7 @@ class MyCluster(Cluster):
         if "securityConfiguration" in self.config:
             extraArgs["SecurityConfiguration"] = self.config["securityConfiguration"]
         if self.config.get("ebsRootVolumeSize", 0):
-            extraArgs["EbsRootVolumeSize"] = self.config["ebsRootVolumeSize"]
+            extraArgs["EbsRootVolumeSize"] = int(self.config["ebsRootVolumeSize"])
         
         security_groups = []
         if "additionalSecurityGroups" in self.config:
@@ -55,7 +55,7 @@ class MyCluster(Cluster):
             instances['InstanceGroups'].append({
                 'InstanceRole': 'CORE',
                 'InstanceType': self.config["coreInstanceType"],
-                'InstanceCount': self.config["coreInstanceCount"]
+                'InstanceCount': int(self.config["coreInstanceCount"])
             })
 
         if self.config.get("taskInstanceCount"):
@@ -64,7 +64,7 @@ class MyCluster(Cluster):
             instances['InstanceGroups'].append({
                 'InstanceRole': 'TASK',
                 'InstanceType': self.config["taskInstanceType"],
-                'InstanceCount': self.config["taskInstanceCount"]
+                'InstanceCount': int(self.config["taskInstanceCount"])
             })
 
         if "ec2KeyName" in self.config:

--- a/python-runnables/scale-cluster/runnable.py
+++ b/python-runnables/scale-cluster/runnable.py
@@ -49,7 +49,7 @@ class MyRunnable(Runnable):
         if core_group and core_group["RequestedInstanceCount"] != self.config.get("core_group_target_instances", 0):
             instanceGroupsToModify.append({
                     "InstanceGroupId" : core_group["Id"],
-                    "InstanceCount" : self.config.get("core_group_target_instances", 0)
+                    "InstanceCount" : int(self.config.get("core_group_target_instances", 0))
                 })
         elif not core_group and self.config.get("core_group_target_instances"):
             if not clusterConfig.get("coreInstanceType"):
@@ -57,13 +57,13 @@ class MyRunnable(Runnable):
             instanceGroupsToAdd.append({
                     'InstanceRole': 'CORE',
                     'InstanceType': clusterConfig["coreInstanceType"],
-                    'InstanceCount': self.config["core_group_target_instances"]
+                    'InstanceCount': int(self.config["core_group_target_instances"])
                 })
 
         if task_group and task_group["RequestedInstanceCount"] != self.config.get("task_group_target_instances", 0):
             instanceGroupsToModify.append({
                     "InstanceGroupId" : task_group["Id"],
-                    "InstanceCount" : self.config.get("task_group_target_instances", 0)
+                    "InstanceCount" : int(self.config.get("task_group_target_instances", 0))
                 })
         elif not task_group and self.config.get("task_group_target_instances"):
             if not clusterConfig.get("taskInstanceType"):
@@ -71,7 +71,7 @@ class MyRunnable(Runnable):
             instanceGroupsToAdd.append({
                     'InstanceRole': 'TASK',
                     'InstanceType': clusterConfig["taskInstanceType"],
-                    'InstanceCount': self.config["task_group_target_instances"]
+                    'InstanceCount': int(self.config["task_group_target_instances"])
                 })
 
         if instanceGroupsToAdd:


### PR DESCRIPTION
Per Dataiku's [plugin parameter documentation](https://doc.dataiku.com/dss/latest/plugins/reference/params.html), parameters declared as `INT` will be deserialised to a float. This now breaks DSS's Start Cluster command with:

```
com.dataiku.dip.io.SocketBlockLinkKernelException
Failed to start cluster : <class 'botocore.exceptions.ParamValidationError'> : Parameter validation failed: Invalid type for parameter Instances.InstanceGroups[0].EbsConfiguration.EbsBlockDeviceConfigs[0].VolumeSpecification.SizeInGB, value: 512.0, type: <type 'float'>, valid types: <type 'int'>, <type 'long'> Invalid type for parameter Instances.InstanceGroups[1].EbsConfiguration.EbsBlockDeviceConfigs[0].VolumeSpecification.SizeInGB, value: 512.0, type: <type 'float'>, valid types: <type 'int'>, <type 'long'> Invalid type for parameter Instances.InstanceGroups[1].InstanceCount, value: 1.0, type: <type 'float'>, valid types: <type 'int'>, <type 'long'>
```

This issue is documented in Dataiku internal support ticket #14154.

This pull request explicitly casts all `INT` parameters as... `int`.
