### PR TITLE
Cross Account EMR with Glue Metastore

### DIFF
--- a/python-clusters/emr-attach-to-existing-cluster/cluster.json
+++ b/python-clusters/emr-attach-to-existing-cluster/cluster.json
@@ -20,33 +20,30 @@
             "mandatory": true
         },
         {
-            "name": "useCrossAccount",
-            "label": "Using Multiple AWS Accounts",
-            "type": "BOOLEAN"
-        },
-        {
             "name": "useRole",
             "label": "Assume Role",
-            "type": "BOOLEAN",
-            "visibilityCondition": "model.useCrossAccount"
+            "type": "BOOLEAN"
         },
         {
             "name": "accessKey",
             "label": "AWS Access Key",
+            "description": "If empty, uses AWS credentials from the environment (IAM role, ~/.aws/credentials or AWS_ACCESS_KEY_ID environment variable)",
             "type": "STRING",
-            "visibilityCondition": "model.useCrossAccount && !model.useRole"
+            "visibilityCondition": "!model.useRole"
         },
         {
             "name": "secretKey",
             "label": "AWS Secret Key",
+            "description": "If empty, uses AWS credentials from the environment (IAM role, ~/.aws/credentials or AWS_ACCESS_KEY_ID environment variable)",
             "type": "STRING",
-            "visibilityCondition": "model.useCrossAccount && !model.useRole"
+            "visibilityCondition": "!model.useRole"
         },
         {
             "name": "assumeRole",
             "label": "Role ARN",
+            "description": "If empty, uses AWS credentials from the environment (IAM role, ~/.aws/credentials or AWS_ACCESS_KEY_ID environment variable)",
             "type": "STRING",
-            "visibilityCondition": "model.useCrossAccount && model.useRole"
+            "visibilityCondition": "model.useRole"
         }
     ],
     "actions": [

--- a/python-clusters/emr-attach-to-existing-cluster/cluster.json
+++ b/python-clusters/emr-attach-to-existing-cluster/cluster.json
@@ -1,34 +1,61 @@
 {
-    "meta" : {
-        "label" : "EMR cluster (attach to existing cluster)",
-        "description" : "Creates a DSS cluster to attach to an existing EMR cluster",
-        "icon" : "icon-puzzle-piece"
+    "meta": {
+        "label": "EMR cluster (attach to existing cluster)",
+        "description": "Creates a DSS cluster to attach to an existing EMR cluster",
+        "icon": "icon-puzzle-piece"
     },
-
     "params": [
         {
-            "name" : "awsRegionId",
-            "label" : "AWS Region",
-            "type": "STRING", 
+            "name": "awsRegionId",
+            "label": "AWS Region",
+            "type": "STRING",
             "description": "AWS region id, leave empty to use region of current instance",
-            "mandatory" : false,
+            "mandatory": false,
             "defaultValue": "us-east-1"
         },
         {
             "name": "emrClusterId",
-            "label" : "EMR cluster Id",
+            "label": "EMR cluster Id",
             "type": "STRING",
-            "mandatory" : true
+            "mandatory": true
+        },
+        {
+            "name": "useCrossAccount",
+            "label": "Using Multiple AWS Accounts",
+            "type": "BOOLEAN"
+        },
+        {
+            "name": "useRole",
+            "label": "Assume Role",
+            "type": "BOOLEAN",
+            "visibilityCondition": "model.useCrossAccount"
+        },
+        {
+            "name": "accessKey",
+            "label": "AWS Access Key",
+            "type": "STRING",
+            "visibilityCondition": "model.useCrossAccount && !model.useRole"
+        },
+        {
+            "name": "secretKey",
+            "label": "AWS Secret Key",
+            "type": "STRING",
+            "visibilityCondition": "model.useCrossAccount && !model.useRole"
+        },
+        {
+            "name": "assumeRole",
+            "label": "Role ARN",
+            "type": "STRING",
+            "visibilityCondition": "model.useCrossAccount && model.useRole"
         }
     ],
-    
-    "actions" : [
+    "actions": [
         {
-            "id" : "fetch-nodes-keys",
-            "meta" : {
-                "label" : "Fetch node description keys",
-                "description" : "Fetches node description keys",
-                "icon" : "icon-search"
+            "id": "fetch-nodes-keys",
+            "meta": {
+                "label": "Fetch node description keys",
+                "description": "Fetches node description keys",
+                "icon": "icon-search"
             }
         }
     ]

--- a/python-clusters/emr-attach-to-existing-cluster/cluster.py
+++ b/python-clusters/emr-attach-to-existing-cluster/cluster.py
@@ -16,7 +16,7 @@ class MyCluster(Cluster):
        
     def start(self):
         region_name = self.config.get("awsRegionId") or dku_emr.get_current_region()
-        client = boto3.client("emr", region_name=region_name)
+        client = dku_emr.get_emr_client(self.config, region_name)
         clusterId = self.config["emrClusterId"]
         logging.info("Attaching to EMR cluster id %s" % clusterId)
         return dku_emr.make_cluster_keys_and_data(client, clusterId, create_user_dir=True)

--- a/python-clusters/emr-create-cluster/cluster.json
+++ b/python-clusters/emr-create-cluster/cluster.json
@@ -130,9 +130,7 @@
             "selectChoices" : [
                 {"value" : "TRANSIENT", "label" : "Transient (cluster-specific)"},
                 {"value" : "MYSQL", "label" : "External MySQL or Aurora DB"},
-                {"value" : "CUSTOM_JDBC", "label" : "Custom settings (JDBC)"}
-            ],
-            "disabledSelectChoices" : [
+                {"value" : "CUSTOM_JDBC", "label" : "Custom settings (JDBC)"},
                 {"value": "AWS_GLUE_DATA_CATALOG", "label" : "Use AWS Glue Data Catalog"}
             ],
             "mandatory" : true

--- a/python-clusters/emr-create-cluster/cluster.json
+++ b/python-clusters/emr-create-cluster/cluster.json
@@ -10,46 +10,6 @@
     "params": [
         {
             "type" : "SEPARATOR",
-            "label":  "Cross-Account Configuration"
-        },
-        {
-            "name": "useCrossAccount",
-            "label": "Using Multiple AWS Accounts",
-            "type": "BOOLEAN"
-        },
-        {
-            "name": "useRole",
-            "label": "Assume Role",
-            "type": "BOOLEAN",
-            "visibilityCondition": "model.useCrossAccount"
-        },
-        {
-            "name": "accessKey",
-            "label": "AWS Access Key",
-            "type": "STRING",
-            "visibilityCondition": "model.useCrossAccount && !model.useRole"
-        },
-        {
-            "name": "secretKey",
-            "label": "AWS Secret Key",
-            "type": "STRING",
-            "visibilityCondition": "model.useCrossAccount && !model.useRole"
-        },
-        {
-            "name": "assumeRole",
-            "label" : "Role ARN",
-            "type": "STRING",
-            "visibilityCondition": "model.useRole && model.useCrossAccount"
-        },
-        {
-            "name": "securityConfig",
-            "label": "EMR Security Configuration",
-            "type": "STRING",
-            "description": "[REQUIRED] EMR Security Configuration to use",
-            "visibilityCondition": "model.useCrossAccount"
-        },
-        {
-            "type" : "SEPARATOR",
             "label":  "Instance Configuration"
         },
         {
@@ -245,14 +205,6 @@
             "mandatory" : false
         },
         {
-            "name": "crossAccountId",
-            "label" : "AWS Account ID",
-            "type": "STRING",
-            "description" : "AWS Account ID where Glue Metastore resides",
-            "visibilityCondition": "model.metastoreDBMode == 'AWS_GLUE_DATA_CATALOG' && model.useCrossAccount"
-        },
-        
-        {
             "type" : "SEPARATOR",
             "label":  "Misc"
         },
@@ -268,6 +220,42 @@
             "type" : "STRING",
             "mandatory": false,
             "description" : "Optional. S3 path where logs will be stored"
+        },
+        {
+            "type": "SEPARATOR",
+            "label": "Advanced"
+        },
+        {
+            "name": "useRole",
+            "label": "Assume Role",
+            "type": "BOOLEAN"
+        },
+        {
+            "name": "assumeRole",
+            "label" : "Role ARN",
+            "description": "If empty, uses AWS credentials from the environment (IAM role, ~/.aws/credentials or AWS_ACCESS_KEY_ID environment variable)",
+            "type": "STRING",
+            "visibilityCondition": "model.useRole"
+        },
+        {
+            "name": "accessKey",
+            "label": "AWS Access Key",
+            "description": "If empty, uses AWS credentials from the environment (IAM role, ~/.aws/credentials or AWS_ACCESS_KEY_ID environment variable)",
+            "type": "STRING",
+            "visibilityCondition": "!model.useRole"
+        },
+        {
+            "name": "secretKey",
+            "label": "AWS Secret Key",
+            "description": "If empty, uses AWS credentials from the environment (IAM role, ~/.aws/credentials or AWS_ACCESS_KEY_ID environment variable)",
+            "type": "STRING",
+            "visibilityCondition": "!model.useRole"
+        },
+        {
+            "name": "securityConfig",
+            "label": "EMR Security Configuration",
+            "type": "STRING",
+            "description": "EMR Security Configuration to use, must already exist"
         }
     ],
     

--- a/python-clusters/emr-create-cluster/cluster.json
+++ b/python-clusters/emr-create-cluster/cluster.json
@@ -9,6 +9,50 @@
 
     "params": [
         {
+            "type" : "SEPARATOR",
+            "label":  "Cross-Account Configuration"
+        },
+        {
+            "name": "useCrossAccount",
+            "label": "Using Multiple AWS Accounts",
+            "type": "BOOLEAN"
+        },
+        {
+            "name": "useRole",
+            "label": "Assume Role",
+            "type": "BOOLEAN",
+            "visibilityCondition": "model.useCrossAccount"
+        },
+        {
+            "name": "accessKey",
+            "label": "AWS Access Key",
+            "type": "STRING",
+            "visibilityCondition": "model.useCrossAccount && !model.useRole"
+        },
+        {
+            "name": "secretKey",
+            "label": "AWS Secret Key",
+            "type": "STRING",
+            "visibilityCondition": "model.useCrossAccount && !model.useRole"
+        },
+        {
+            "name": "assumeRole",
+            "label" : "Role ARN",
+            "type": "STRING",
+            "visibilityCondition": "model.useRole && model.useCrossAccount"
+        },
+        {
+            "name": "securityConfig",
+            "label": "EMR Security Configuration",
+            "type": "STRING",
+            "description": "[REQUIRED] EMR Security Configuration to use",
+            "visibilityCondition": "model.useCrossAccount"
+        },
+        {
+            "type" : "SEPARATOR",
+            "label":  "Instance Configuration"
+        },
+        {
             "name" : "awsRegionId",
             "label" : "AWS Region",
             "type": "STRING", 
@@ -199,6 +243,13 @@
             "defaultValue" : "dataiku",
             "description" : "Comma-separated list of databases to create upon startup",
             "mandatory" : false
+        },
+        {
+            "name": "crossAccountId",
+            "label" : "AWS Account ID",
+            "type": "STRING",
+            "description" : "AWS Account ID where Glue Metastore resides",
+            "visibilityCondition": "model.metastoreDBMode == 'AWS_GLUE_DATA_CATALOG' && model.useCrossAccount"
         },
         
         {

--- a/python-clusters/emr-create-cluster/cluster.py
+++ b/python-clusters/emr-create-cluster/cluster.py
@@ -96,7 +96,7 @@ class MyCluster(Cluster):
             props = {
                 "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
             }
-            Configurations = [{"Classification": "hive-site", "Properties" : props}]
+            Configurations = [{"Classification": "hive-site", "Properties" : props}, {"Classification": "spark-hive-site", "Properties": props}]
             extraArgs["Configurations"] = Configurations
         
         logging.info("Starting cluster: %s", dict(

--- a/python-lib/dku_emr.py
+++ b/python-lib/dku_emr.py
@@ -158,26 +158,25 @@ def get_current_subnet():
 def get_emr_client(config, region):
     """Returns a boto3 EMR client object"""
 
-    cross = config.get("useCrossAccount")
     role = config.get("assumeRole")
-    if cross:
-        if role:
-            sts = boto3.client("sts")
-            try:
-                response = sts.assume_role(RoleArn=role, RoleSessionName="dss-emr-access")
-            except:
-                logging.error("could not assume role %s" % role)
-                traceback.print_exc()
-                raise
-                
-            access_key = response["Credentials"]["AccessKeyId"]
-            secret_key = response["Credentials"]["SecretAccessKey"]
-            session_token = response["Credentials"]["SessionToken"]
-            
-            return boto3.client("emr", region_name=region, aws_access_key_id=access_key, aws_secret_access_key=secret_key, aws_session_token=session_token)
-        else:
-            access_key = config.get("accessKey")
-            secret_key = config.get("secretKey")
+    access_key = config.get("accessKey")
+    secret_key = config.get("secretKey")
 
-            return boto3.client("emr", region_name=region, aws_access_key_id=access_key, aws_secret_access_key=secret_key)
-    return boto3.client('emr', region_name=region)
+    if role:
+        sts = boto3.client("sts")
+        try:
+            response = sts.assume_role(RoleArn=role, RoleSessionName="dss-emr-access")
+        except:
+            logging.error("could not assume role %s" % role)
+            traceback.print_exc()
+            raise
+            
+        access_key = response["Credentials"]["AccessKeyId"]
+        secret_key = response["Credentials"]["SecretAccessKey"]
+        session_token = response["Credentials"]["SessionToken"]
+        
+        return boto3.client("emr", region_name=region, aws_access_key_id=access_key, aws_secret_access_key=secret_key, aws_session_token=session_token)
+    elif access_key and secret_key:
+        return boto3.client("emr", region_name=region, aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    else:
+        return boto3.client('emr', region_name=region)

--- a/python-lib/dku_emr.py
+++ b/python-lib/dku_emr.py
@@ -23,7 +23,7 @@ def get_client_and_wait(started_cluster_settings):
 
     region = config.get("awsRegionId") or get_current_region()
     logging.info("creating Boto client for cluster, region=%s", region)
-    client = boto3.client('emr', region_name=region)
+    client = get_emr_client(config, region)
 
     logging.info("waiting for cluster %s to be running" % data["emrClusterId"])
     waiter = client.get_waiter('cluster_running')
@@ -153,3 +153,31 @@ def get_current_subnet():
         logging.error("could not retrieve current EC2 subnet")
         traceback.print_exc()
         return None
+
+
+def get_emr_client(config, region):
+    """Returns a boto3 EMR client object"""
+
+    cross = config.get("useCrossAccount")
+    role = config.get("assumeRole")
+    if cross:
+        if role:
+            sts = boto3.client("sts")
+            try:
+                response = sts.assume_role(RoleArn=role, RoleSessionName="dss-emr-access")
+            except:
+                logging.error("could not assume role %s" % role)
+                traceback.print_exc()
+                raise
+                
+            access_key = response["Credentials"]["AccessKeyId"]
+            secret_key = response["Credentials"]["SecretAccessKey"]
+            session_token = response["Credentials"]["SessionToken"]
+            
+            return boto3.client("emr", region_name=region, aws_access_key_id=access_key, aws_secret_access_key=secret_key, aws_session_token=session_token)
+        else:
+            access_key = config.get("accessKey")
+            secret_key = config.get("secretKey")
+
+            return boto3.client("emr", region_name=region, aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    return boto3.client('emr', region_name=region)


### PR DESCRIPTION
This PR is for two purposes:

1. Add Glue metastore as an option for the Hive metastore
2. Add the ability to create/attach to EMR clusters across accounts using either an IAM role or using credentials

Given that Glue metastore and cross account stuff can be intertwined, I figured one PR for the two changes.

For adding Glue metastore, refer to AWS docs about configs:

- Hive: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-hive-metastore-glue.html
- Spark: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-glue.html

For cross account EMR, it is likely that metastores are cross account as well. This requires that a security configuration be set so that S3 objects in other account is owned by that account and not the writing account. See below documentation:
https://aws.amazon.com/premiumsupport/knowledge-center/emrfs-cross-account-access/

Tested locally with @JedIV.