### PR TITLE
Ensure cluster shutdown when WaiterError raised during startup

### DIFF
--- a/python-clusters/emr-create-cluster/cluster.py
+++ b/python-clusters/emr-create-cluster/cluster.py
@@ -153,9 +153,12 @@ class MyCluster(Cluster):
         logging.info("clusterId=%s" % clusterId)
         
         logging.info("waiting for cluster to start")
-        client.get_waiter('cluster_running').wait(ClusterId=clusterId)
-        
-        return dku_emr.make_cluster_keys_and_data(client, clusterId, create_user_dir=True, create_databases=self.config.get("databasesToCreate"))
+        try:
+            client.get_waiter('cluster_running').wait(ClusterId=clusterId)
+            return dku_emr.make_cluster_keys_and_data(client, clusterId, create_user_dir=True, create_databases=self.config.get("databasesToCreate"))
+        except:
+            client.terminate_job_flows(JobFlowIds=[clusterId])
+            raise
 
     def stop(self, data):
         """


### PR DESCRIPTION
This PR results from this support ticket: https://support.dataiku.com/a/tickets/19616

In short, the issue seems to be that the cluster sometimes takes longer to start than the default wait time of the boto3 package allows for (30 minutes, see boto3 docs [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Waiter.ClusterRunning.wait)). When this happens, the plugin exits with an exception, and DSS “assumes” that the cluster has not started; however, there seem to be cases when the cluster does eventually start.

In these cases, the started cluster sits on AWS “unattached” to DSS, thus consuming resources with no jobs being submitted to it.

To prevent this from happening (i.e. having unattached clusters started on AWS), my thought was to catch exceptions thrown by the waiter, and send a cluster shutdown command before terminating the plugin script.